### PR TITLE
[Discuss] Use Object.assign instead of destructuring arguments

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -1,13 +1,8 @@
 const AWS = require('aws-sdk');
 
 class Logger {
-    constructor({stage, stack, app, roleArn, streamName, sendLogsToKinesis = true}) {
-        this.stage = stage;
-        this.stack = stack;
-        this.app = app;
-        this.roleArn = roleArn;
-        this.streamName = streamName;
-        this.sendLogsToKinesis = sendLogsToKinesis;
+    constructor(options) {
+        Object.assign(this, { sendLogsToKinesis: true }, options)
         this._logLines = [];
     }
 


### PR DESCRIPTION
@akash1810 Just a thought on what we were discussing yesterday (I didn't test this), but wondered if this pattern is nicer? The required arguments are less clear without jsDoc / Flow types but a little cleaner? Anyway, just a bit of a minor thing bikeshed of a morning.