### PR TITLE
make roleArn optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ const logger = new ELKKinesisLogger({
   stage: 'PROD',
   stack: 'my-stack',
   app: 'my-app',
-  streamName: 'my-stream',
-  roleArn: 'arn:aws:iam::000000000000:role/my-role'
-});
+  streamName: 'my-stream'
+}).withRole('arn:aws:iam::000000000000:role/my-role');
 ```
 
 Open the logger:
@@ -73,7 +72,6 @@ const logger = new ELKKinesisLogger({
   stage: 'PROD',
   stack: 'my-stack',
   app: 'my-app',
-  roleArn: 'arn:aws:iam::000000000000:role/my-role',
   streamName: 'my-stream'
 });
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,18 @@ const logger = new ELKKinesisLogger({
   stage: 'PROD',
   stack: 'my-stack',
   app: 'my-app',
-  roleArn: 'arn:aws:iam::000000000000:role/my-role',
   streamName: 'my-stream'
+});
+```
+
+If the stream's access is restricted, you can specify a role arn to assume:
+```js
+const logger = new ELKKinesisLogger({
+  stage: 'PROD',
+  stack: 'my-stack',
+  app: 'my-app',
+  streamName: 'my-stream',
+  roleArn: 'arn:aws:iam::000000000000:role/my-role'
 });
 ```
 

--- a/examples/advanced-example.js
+++ b/examples/advanced-example.js
@@ -4,11 +4,10 @@ const options = {
   stage: process.env.STAGE,
   stack: process.env.STACK,
   app: 'elk-kinesis-logger',
-  roleArn: process.env.ROLE_ARN,
   streamName: process.env.STREAM_NAME
 };
 
-const logger = new ELKKinesisLogger(options);
+const logger = new ELKKinesisLogger(options).withRole(process.env.ROLE_ARN);
 
 logger
   .open()

--- a/examples/simple-example.js
+++ b/examples/simple-example.js
@@ -4,7 +4,6 @@ const options = {
   stage: process.env.STAGE,
   stack: process.env.STACK,
   app: 'elk-kinesis-logger',
-  roleArn: process.env.ROLE_ARN,
   streamName: process.env.STREAM_NAME
 };
 

--- a/src/elk-kinesis-logger.js
+++ b/src/elk-kinesis-logger.js
@@ -1,13 +1,17 @@
 const AWS = require('aws-sdk');
 
 class ELKKinesisLogger {
-  constructor({ stage, stack, app, roleArn, streamName, verbose = true }) {
+  constructor({ stage, stack, app, streamName, verbose = true }) {
     this.stage = stage;
     this.stack = stack;
     this.app = app;
-    this.roleArn = roleArn;
     this.streamName = streamName;
     this.verbose = verbose;
+  }
+
+  withRole(roleArn) {
+    this.roleArn = roleArn;
+    return this;
   }
 
   get _name() {

--- a/test/elk-kinesis-logger.js
+++ b/test/elk-kinesis-logger.js
@@ -4,16 +4,7 @@ const MockDate = require('mockdate');
 const ELKKinesisLogger = require('../src/elk-kinesis-logger');
 
 describe('ELKKinesisLogger', () => {
-  const configWithRoleArn = {
-    stage: 'TEST',
-    stack: 'elk-kinesis-logger',
-    app: 'elk-kinesis-logger-tests',
-    roleArn: 'test-role',
-    streamName: 'test-stream',
-    verbose: false
-  };
-
-  const configWithoutRoleArn = {
+  const config = {
     stage: 'TEST',
     stack: 'elk-kinesis-logger',
     app: 'elk-kinesis-logger-tests',
@@ -49,7 +40,7 @@ describe('ELKKinesisLogger', () => {
   });
 
   it('should raise an error if not opened', () => {
-    const logger = new ELKKinesisLogger(configWithRoleArn);
+    const logger = new ELKKinesisLogger(config);
 
     try {
       logger.log('test');
@@ -61,8 +52,8 @@ describe('ELKKinesisLogger', () => {
     }
   });
 
-  it('should write a simple log to kinesis (without role)', done => {
-    const logger = new ELKKinesisLogger(configWithoutRoleArn);
+  it('should write a simple log to kinesis (with role)', done => {
+    const logger = new ELKKinesisLogger(config).withRole('test-role');
 
     logger.open().then(() => {
       logger.log(logMsg);
@@ -82,11 +73,12 @@ describe('ELKKinesisLogger', () => {
           ];
 
           const kinesisMsg = {
-            StreamName: configWithRoleArn.streamName,
+            StreamName: config.streamName,
             PartitionKey: 'logs',
             Data: JSON.stringify(expected[0])
           };
 
+          assert.equal('test-role', logger.roleArn);
           assert.equal(true, logger.kinesis.putRecord.calledOnce);
           assert.equal(true, logger.kinesis.putRecord.calledWith(kinesisMsg));
           assert.deepEqual(actual, expected);
@@ -96,8 +88,8 @@ describe('ELKKinesisLogger', () => {
     });
   });
 
-  it('should write a simple log to kinesis (with role)', done => {
-    const logger = new ELKKinesisLogger(configWithRoleArn);
+  it('should write a simple log to kinesis', done => {
+    const logger = new ELKKinesisLogger(config);
 
     logger.open().then(() => {
       logger.log(logMsg);
@@ -117,7 +109,7 @@ describe('ELKKinesisLogger', () => {
           ];
 
           const kinesisMsg = {
-            StreamName: configWithRoleArn.streamName,
+            StreamName: config.streamName,
             PartitionKey: 'logs',
             Data: JSON.stringify(expected[0])
           };
@@ -132,7 +124,7 @@ describe('ELKKinesisLogger', () => {
   });
 
   it('should write a log with extra detail to kinesis', done => {
-    const logger = new ELKKinesisLogger(configWithRoleArn);
+    const logger = new ELKKinesisLogger(config);
 
     logger.open().then(() => {
       const extraDetail = {
@@ -157,7 +149,7 @@ describe('ELKKinesisLogger', () => {
           ];
 
           const kinesisMsg = {
-            StreamName: configWithRoleArn.streamName,
+            StreamName: config.streamName,
             PartitionKey: 'logs',
             Data: JSON.stringify(expected[0])
           };
@@ -173,7 +165,7 @@ describe('ELKKinesisLogger', () => {
   });
 
   it('should write multiple logs', done => {
-    const logger = new ELKKinesisLogger(configWithRoleArn);
+    const logger = new ELKKinesisLogger(config);
 
     logger.open().then(() => {
       logger.log('first message');
@@ -222,7 +214,7 @@ describe('ELKKinesisLogger', () => {
           expected
             .map(ex => {
               return {
-                StreamName: configWithRoleArn.streamName,
+                StreamName: config.streamName,
                 PartitionKey: 'logs',
                 Data: JSON.stringify(ex)
               };
@@ -244,7 +236,7 @@ describe('ELKKinesisLogger', () => {
   });
 
   it('should write logs of multiple levels', done => {
-    const logger = new ELKKinesisLogger(configWithRoleArn);
+    const logger = new ELKKinesisLogger(config);
 
     logger.open().then(() => {
       logger.log('first message');
@@ -293,7 +285,7 @@ describe('ELKKinesisLogger', () => {
           expected
             .map(ex => {
               return {
-                StreamName: configWithRoleArn.streamName,
+                StreamName: config.streamName,
                 PartitionKey: 'logs',
                 Data: JSON.stringify(ex)
               };


### PR DESCRIPTION
By default, don't us a role. If you need to use a role, then call `.withRole()`:

```js
const logger = new ELKKinesisLogger(options);
const loggerWithRole = new ELKKinesisLogger(options).withRole('my-role');
```